### PR TITLE
ci: add ci checks

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,34 @@
+# This file should be the only depenency on GitHub Actions. Minimizing the
+# dependency on GitHub actions will make it easier to migrate to other CI/CD
+# tools if required and much of what it does can better served by a build
+# system.
+name: ci
+
+on:
+  pull_request:
+    branches:
+      - main
+  merge_group:
+    branches:
+      - main
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+    - name: Setup Python
+      uses: actions/setup-python@v3
+    # PR CI is run on PRs and merge queue, to ensure that the PR is working
+    # before consuming resources on the merge queue. The merge Queue CI needs
+    # to re-run the PR to ensure it works with other PRs in the merge queue.
+    - name: PR CI
+      uses: pre-commit/action@v3.0.1
+    - name: Merge CI
+      # Merge queue CI is run only on the merge queue.
+      if: github.event_name == 'merge_group'
+      run: |
+        python -m pip install commitizen
+        git log -1 --format=%B HEAD >| commit_msg.txt
+        cz check --commit-msg-file commit_msg.txt

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-default_install_hook_types: [pre-commit, commit-msg]
+default_install_hook_types: [pre-commit]
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v3.2.0
@@ -11,8 +11,3 @@ repos:
       stages: [pre-commit]
     - id: check-added-large-files
       stages: [pre-commit]
-  - repo: https://github.com/commitizen-tools/commitizen
-    rev: v3.27.0
-    hooks:
-    - id: commitizen
-      stages: [commit-msg]


### PR DESCRIPTION
add ci.yml to run on PR and merge_queue. The PR will run pre-commit checks and merge_queue will run pre-commit checks and confirm that the PR title + description follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)