### PR TITLE
ci: run vale on merge queue

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,7 +30,7 @@ jobs:
         uses: errata-ai/vale-action@reviewdog
         with:
           fail_on_error: true
-          reporter: github-pr-check
+          reporter: github-check
       - name: Merge CI
         # Merge queue CI is run only on the merge queue.
         if: github.event_name == 'merge_group'


### PR DESCRIPTION
# PR Checklist

- [x] The PR message follows https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tests have been added or updated
- [x] Documentation has been added or updated

# PR Description

Use github-check instead of github-pr-check when calling reviewdog, this will allow it to run on merge queue and on PR.
